### PR TITLE
Copied these global vars from main.cpp to fix compilation error

### DIFF
--- a/urlinfo.cpp
+++ b/urlinfo.cpp
@@ -16,6 +16,8 @@
 bool mainShutdown ( bool urgent ) { return true; }
 bool closeAll ( void *state , void (* callback)(void *state) ) {return true;}
 bool allExit ( ) { return true; }
+long g_qbufNeedSave = false;
+SafeBuf g_qbuf;
 
 int main ( int argc , char *argv[] ) {
 	bool addWWW = true;


### PR DESCRIPTION
`make urlinfo` fails, appears to be a missing include or missing globals in urlinfo.cpp.

Process.o: In function `Process::saveBlockingFiles1()':
/home/coconutpilot/work/open-source-search-engine/Process.cpp:1549: undefined reference to`g_qbufNeedSave'
/home/coconutpilot/work/open-source-search-engine/Process.cpp:1552: undefined reference to `g_qbuf'
/home/coconutpilot/work/open-source-search-engine/Process.cpp:1554: undefined reference to`g_qbufNeedSave'
Process.o: In function `Process::resetAll()':
/home/coconutpilot/work/open-source-search-engine/Process.cpp:1717: undefined reference to`g_qbuf'
collect2: ld returned 1 exit status
make: **\* [urlinfo] Error 1
