### PR TITLE
Optimize UTF-8 handling

### DIFF
--- a/Posdb.cpp
+++ b/Posdb.cpp
@@ -5915,7 +5915,6 @@ void PosdbTable::intersectLists10_r ( ) {
 #define RINGBUFSIZE 4096
 //#define RINGBUFSIZE 1024
 	unsigned char ringBuf[RINGBUFSIZE+10];
-	unsigned char *ringBufEnd = ringBuf + RINGBUFSIZE;
 	// for overflow conditions in loops below
 	ringBuf[RINGBUFSIZE+0] = 0xff;
 	ringBuf[RINGBUFSIZE+1] = 0xff;
@@ -6264,18 +6263,7 @@ void PosdbTable::intersectLists10_r ( ) {
 	// for 'search engine'. it might save time!
 
 	// reset ring buf. make all slots 0xff. should be 1000 cycles or so.
-	for ( int32_t *rb = (int32_t *)ringBuf ; ; ) {
-		rb[0] = 0xffffffff;
-		rb[1] = 0xffffffff;
-		rb[2] = 0xffffffff;
-		rb[3] = 0xffffffff;
-		rb[4] = 0xffffffff;
-		rb[5] = 0xffffffff;
-		rb[6] = 0xffffffff;
-		rb[7] = 0xffffffff;
-		rb += 8;
-		if ( rb >= (int32_t *)ringBufEnd ) break;
-	}
+	memset ( ringBuf, 0xff, RINGBUFSIZE );
 
 	// now to speed up 'time enough for love' query which does not
 	// have many super high scoring guys on top we need a more restrictive

--- a/Unicode.h
+++ b/Unicode.h
@@ -66,15 +66,26 @@ static int utf8_sane[] = {
 
 // how many bytes is char pointed to by p?
 inline char getUtf8CharSize ( uint8_t *p ) {
-	return bytes_in_utf8_code[*p];
+	uint8_t c = *p;
+	if(c<128)
+		return 1;
+	else
+		return bytes_in_utf8_code[c];
 }
 
 inline char getUtf8CharSize ( char *p ) {
-	return bytes_in_utf8_code[*(uint8_t *)p];
+	uint8_t c = (uint8_t)*p;
+	if(c<128)
+		return 1;
+	else
+		return bytes_in_utf8_code[c];
 }
 
 inline char getUtf8CharSize ( uint8_t c ) {
-	return bytes_in_utf8_code[c];
+	if(c<128)
+		return 1;
+	else
+		return bytes_in_utf8_code[c];
 }
 
 inline char getUtf8CharSize2 ( uint8_t *p ) {

--- a/fctypes.h
+++ b/fctypes.h
@@ -237,7 +237,7 @@ bool saveTimeAdjustment ( ) ;
 #define is_hspace_a(c)         g_map_is_hspace[(unsigned char)c]
 #define is_ascii(c)           g_map_is_ascii[(unsigned char)c]
 #define is_ascii9(c)           g_map_is_ascii[(unsigned char)c]
-#define is_ascii3(c)           g_map_is_ascii3[(unsigned char)c]
+#define is_ascii3(c)           ((unsigned char)c<128 || g_map_is_ascii3[(unsigned char)c])
 #define is_punct_a(c)          g_map_is_punct[(unsigned char)c]
 #define is_alnum_a(c)          g_map_is_alnum[(unsigned char)c]
 #define is_alpha_a(c)          g_map_is_alpha[(unsigned char)c]


### PR DESCRIPTION
Trivial logic/tests are cheaper than table lookups.

The CPU/memory speed disparity has grown the past 10 years so a L1 cache fetch costs approximately 4 cycles. With branch prediction and IPC>1 that means that if peice of logica can be done with either a few trivial instructions or a memory fetch then the former should be used.

The two patches increase speed of searches by 6% rsp. 3%