### PR TITLE
Fix segfault when using add URL

### DIFF
--- a/PageRoot.cpp
+++ b/PageRoot.cpp
@@ -2524,7 +2524,11 @@ bool sendPageAddUrl ( TcpSocket *sock , HttpRequest *hr ) {
 	ir->ptr_url = hr->getString("u",NULL);
 	if ( ! ir->ptr_url ) ir->ptr_url = hr->getString("url",NULL);
 	if ( ! ir->ptr_url ) ir->ptr_url = hr->getString("urls",NULL);
-	
+
+	if ( ir->ptr_url ) {
+		ir->size_url = gbstrlen(ir->ptr_url) + 1;
+	}
+
 	// get back a short reply so we can show the status code easily
 	ir->m_shortReply = 1;
 


### PR DESCRIPTION
Using "Add URL" will cause a segfault because size_url is not filled in.