### PR TITLE
Fixes to build project with gcc 12.2.0

### DIFF
--- a/Unicode.cpp
+++ b/Unicode.cpp
@@ -1743,8 +1743,8 @@ bool openIconvDescriptors() {
 		}
 	}
 	// ...and the ones that don't involve utf16
-	if (gbiconv_open("UTF-8", "WINDOWS-1252") < 0) return false;
-	if (gbiconv_open("WINDOWS-1252", "UTF-8") < 0) return false;
+	if (gbiconv_open("UTF-8", "WINDOWS-1252") == (iconv_t)-1) return false;
+	if (gbiconv_open("WINDOWS-1252", "UTF-8") == (iconv_t)-1) return false;
 	
 	//log(LOG_INIT, "uni: Successfully loaded all iconv descriptors");
 	return true;

--- a/Xml.cpp
+++ b/Xml.cpp
@@ -1199,7 +1199,7 @@ char *Xml::getItemLink ( int32_t *linkLen ) {
 		link     = m_nodes[i+1].m_node;
 		*linkLen = m_nodes[i+1].m_nodeLen;
 
-		if ( link && &linkLen > 0 ) return link;
+		if ( link && *linkLen > 0 ) return link;
 	}
 	// no link found, return NULL
 	*linkLen = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -17594,7 +17594,7 @@ void countdomains( char* coll, int32_t numRecs, int32_t verbosity, int32_t outpu
 		if( output != 9 ) goto printHtml;
 		// Dump raw data to a file to parse later
 		sprintf( out, "%scntdom.xml", g_hostdb.m_dir );
-		if( (fhndl = fopen( out, "wb" )) < 0 ) {
+		if( (fhndl = fopen( out, "wb" )) == NULL ) {
 			log( LOG_INFO, "cntDm: File Open Failed." );
 			return;
 		}
@@ -17738,7 +17738,7 @@ void countdomains( char* coll, int32_t numRecs, int32_t verbosity, int32_t outpu
 	printHtml:
 		// HTML file Output
 		sprintf( out, "%scntdom.html", g_hostdb.m_dir );
-		if( (fhndl = fopen( out, "wb" )) < 0 ) {
+		if( (fhndl = fopen( out, "wb" )) == 0 ) {
 			log( LOG_INFO, "cntDm: File Open Failed." );
 			return;
 		}		


### PR DESCRIPTION
Hi,
I've made few fixes to build project with gcc 12. 

I've tested this on Debian testing, using `g++ (Debian 12.2.0-1) 12.2.0`,
and the following build command:

`CC_OPT_ARG="-O0 -std=c++11" make`

However, the number of compiler warnings is overwhelming. I tend to fix them later starting from smaller source files like `Log.h` and `Hash.h` if PR this will be accepted.

